### PR TITLE
Added script to install MongoDB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,4 +12,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision "shell", path: path + "/scripts/customizations.sh"
 
+  config.vm.provision "shell", path: path + "/scripts/mongodb.sh"
+
 end

--- a/scripts/mongodb.sh
+++ b/scripts/mongodb.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+echo ">>> Installing MongoDB"
+
+# Get key and add to sources
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+
+# Update
+sudo apt-get update
+
+# Install MongoDB
+# -qq implies -y --force-yes
+sudo apt-get install -qq mongodb-org
+
+# Make MongoDB connectable from outside world without SSH tunnel
+if [ $1 == "true" ]; then
+    # enable remote access
+    # setting the mongodb bind_ip to allow connections from everywhere
+    sed -i "s/bind_ip = */bind_ip = 0.0.0.0/" /etc/mongod.conf
+fi
+
+# Test if PHP is installed
+php -v > /dev/null 2>&1
+PHP_IS_INSTALLED=$?
+
+if [ $PHP_IS_INSTALLED -eq 0 ]; then
+    # install dependencies
+    sudo apt-get -y install php-pear php5-dev
+
+    # install php extencion
+    echo "no" > answers.txt
+    sudo pecl install mongo < answers.txt
+    rm answers.txt
+
+    # add extencion file and restart service
+    echo 'extension=mongo.so' | sudo tee /etc/php5/mods-available/mongo.ini
+
+    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/fpm/conf.d/mongo.ini
+    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/cli/conf.d/mongo.ini
+    sudo service php5-fpm restart
+fi


### PR DESCRIPTION
#### What's this PR do?

Runs a script to install MongoDB on `$ vagrant provision`.

The `mongodb.sh` script was taken from [Vaprobash](https://github.com/fideloper/Vaprobash/blob/master/scripts/mongodb.sh).

Tested successfully with a local install of the [user-api](https://github.com/DoSomething/user-api) project.
#### Any background context?

The **user-api** will be using Mongo, and it's foreseeable that other future Laravel projects will too. So ... here you go!

cc: @weerd @DFurnes @angaither 
