### PR TITLE
Updates README.MD and Homestead.default.yaml.

### DIFF
--- a/Homestead.default.yaml
+++ b/Homestead.default.yaml
@@ -8,31 +8,31 @@ authorize: /Users/USER_NAME_HERE/.ssh/id_rsa.pub
 keys:
     - /Users/USER_NAME_HERE/.ssh/id_rsa
 
-# map: /Users/USER_NAME_HERE/Sites/laravel 
-# Set the path to the directory containing both Homestead and any 
-# Laravel projects on your local machine. 
+# map: /Users/USER_NAME_HERE/Sites/laravel
+# Set the path to the directory containing both Homestead and any
+# Laravel projects on your local machine.
 # Feel free to change this to your preferred setup.
-# 
+#
 # to: /home/vagrant/Sites
-# Set the path on the Vagrant virtual machine to the directory which 
+# Set the path on the Vagrant virtual machine to the directory which
 # reflects the projects in the mapped local directory specified.
 folders:
-    - map: /Users/USER_NAME_HERE/Sites/laravel
-      to: /home/vagrant/Sites
+    - map: /Users/USER_NAME_HERE/Sites/LARAVEL_PROJECT_NAME_HERE
+      to: /home/vagrant/Sites/LARAVEL_PROJECT_NAME_HERE
 
 
 # map: LARAVEL_PROJECT_NAME_HERE.dev
 # Set the custom URL of the project on the virtual machine, to
 # access it locally. *Remember* to add this custom URL to your
 # local machine's "/etc/hosts" file!
-# 
+#
 # to: /home/vagrant/Sites/LARAVEL_PROJECT_NAME_HERE/public
 # Set the path where to map the custom URL on the virtual machine.
 # This path should point to the "/public" directory of the specified
 # Laravel project on the virtual machine.
 sites:
     - map: LARAVEL_PROJECT_NAME_HERE.dev
-      to: /home/vagrant/Sites/LARAVEL_PROJECT_NAME_HERE/public  
+      to: /home/vagrant/Sites/LARAVEL_PROJECT_NAME_HERE/public
 
 variables:
     - key: APP_ENV

--- a/readme.md
+++ b/readme.md
@@ -52,11 +52,6 @@ You will also need to add the custom URLs you declared in the *sites* section to
 
     127.0.0.1  project_name.dev
 
-Make sure to restart your local apache server to pick up the new domains, using:
-
-    $ sudo service nginx restart
-
-
 ### Install Vagrant Plugin
 
 To keep the injected VirtualBox OS additions up to date in your Vagrant boxes, run this command from the root of your ds-homestead directory.
@@ -70,9 +65,9 @@ Now we can start the virtual machine by running the **up** command:
 
     $ vagrant up
 
-If you have added the domain to your **hosts** file, you can access the site via your web browser on port:
+If you have added the domain to your **hosts** file, you can access the site via your web browser on port *8000*:
 
-    http://project_name.dev
+    http://project_name.dev:8000
 
 
 ### SSH into virtual machine

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,9 @@
 
 The official Laravel local development environment, tweaked for DoSomething.org developers.
 
-**Homestead** requires the use of **Virtual Box** and **Vagrant**. The current version of Homestead has been built and tested using version 1.6 of Vagrant, but still works great on **version 1.5.4**, which is the required version used for the DoSomething.org Drupal site.
+**Homestead** requires the use of **Virtual Box** and **Vagrant**. The current version of Homestead has been built and tested using version 1.7.2 of Vagrant.
 
-If you haven't already, download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant](http://www.vagrantup.com/download-archive/v1.5.4.html).
+If you haven't already, download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant](https://www.vagrantup.com/downloads.html).
 
 Homestead includes:
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ You will also need to add the custom URLs you declared in the *sites* section to
 
 Make sure to restart your local apache server to pick up the new domains, using:
 
-    $ sudo apachectl restart
+    $ sudo service nginx restart
 
 
 ### Install Vagrant Plugin
@@ -70,9 +70,9 @@ Now we can start the virtual machine by running the **up** command:
 
     $ vagrant up
 
-If you have added the domain to your **hosts** file, you can access the site via your web browser on port *8000*:
-  
-    http://project_name.dev:8000
+If you have added the domain to your **hosts** file, you can access the site via your web browser on port:
+
+    http://project_name.dev
 
 
 ### SSH into virtual machine
@@ -83,11 +83,11 @@ If your Homestead directory sits at the same level as your Laravel project direc
 
 Then use the following command:
 
-    $ ssh vagrant@127.0.0.1 -p 2222
+    $ vagrant ssh
 
 It would be useful to save the above command to an alias for easier access:
 
-    alias vm='ssh vagrant@127.0.0.1 -p 2222'
+    alias vs='vagrant ssh'
 
 
 ## Troubleshooting
@@ -97,7 +97,6 @@ You can also disable key checking for your local machine by adding the following
     Host 127.0.0.1
       StrictHostKeyChecking no
       UserKnownHostsFile=/dev/null
-
 
 
 ***


### PR DESCRIPTION
#### Homestead.default.yaml
- Trim spaces
- Fix `folders` example, the old one produces 'No input file' error

#### readme.md
- Apache isn't shipped with Homestead anymore, it got replaced by nginx/php-fpm
- `vagrant ssh` is the right (and most easier) way to log into Vagrant