### PR TITLE
Locking Homestead box version to v0.3.0 to not utilize PHP 7

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   Homestead.configure(config, YAML::load(File.read(path + '/Homestead.yaml')))
 
+  config.vm.box_version	= "0.3.0"
+
   config.vm.provision "shell", path: path + "/scripts/customizations.sh"
 
   config.vm.provision "shell", path: path + "/scripts/mongodb.sh"


### PR DESCRIPTION
#### What's this PR do?
Locks Homestead box version to v0.3.0. 
#### Where should the reviewer start?
https://github.com/DoSomething/ds-homestead/blob/php-56-lock/Vagrantfile#L13
#### How should this be manually tested?
Vagrant up with the new branch's Vagrantfile.
#### Any background context you want to provide?
Latest Homestead release includes PHP7, which we don't currently support.
#### What are the relevant tickets?
https://github.com/DoSomething/ds-homestead/issues/8
