### PR TITLE
Use modern MongoDB extension.

### DIFF
--- a/scripts/customizations.sh
+++ b/scripts/customizations.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# Install Bundler gem
-gem install bundler
-
-
 # Update Composer to latest version
 /usr/local/bin/composer self-update
 

--- a/scripts/mongodb.sh
+++ b/scripts/mongodb.sh
@@ -26,17 +26,15 @@ PHP_IS_INSTALLED=$?
 
 if [ $PHP_IS_INSTALLED -eq 0 ]; then
     # install dependencies
-    sudo apt-get -y install php-pear php5-dev
+    sudo apt-get -y install php-pear php5-dev pkg-config
 
     # install php extencion
-    echo "no" > answers.txt
-    sudo pecl install mongo < answers.txt
-    rm answers.txt
+    sudo pecl install mongodb
 
     # add extencion file and restart service
-    echo 'extension=mongo.so' | sudo tee /etc/php5/mods-available/mongo.ini
+    echo 'extension=mongodb.so' | sudo tee /etc/php5/mods-available/mongodb.ini
 
-    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/fpm/conf.d/mongo.ini
-    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/cli/conf.d/mongo.ini
+    ln -s /etc/php5/mods-available/mongodb.ini /etc/php5/fpm/conf.d/mongodb.ini
+    ln -s /etc/php5/mods-available/mongodb.ini /etc/php5/cli/conf.d/mongodb.ini
     sudo service php5-fpm restart
 fi


### PR DESCRIPTION
#### Changes
Updates the Homestead box to use the new version of the PHP MongoDB extension, which is required for v3 of the Laravel MongoDB package which we use. Some context from the [official MongoDB documentation](https://docs.mongodb.com/ecosystem/drivers/php/#drivers) for the PHP extension:

> The currently maintained driver is the mongodb extension available from PECL… There is also an older legacy driver called mongo. New projects should use the mongodb extension with the PHP library. The links below point to the documentation for the new mongodb extension.

I also removed the step which installs Bundler, since we do not use it.

---
For review: @blisteringherb 
/cc @angaither 