### PR TITLE
Install old Mongo extension too.

### DIFF
--- a/scripts/mongodb.sh
+++ b/scripts/mongodb.sh
@@ -29,12 +29,17 @@ if [ $PHP_IS_INSTALLED -eq 0 ]; then
     sudo apt-get -y install php-pear php5-dev pkg-config
 
     # install php extencion
+    sudo pecl install mongo
     sudo pecl install mongodb
 
     # add extencion file and restart service
-    echo 'extension=mongodb.so' | sudo tee /etc/php5/mods-available/mongodb.ini
+    echo 'extension=mongo.so' | sudo tee /etc/php5/mods-available/mongo.ini
+    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/fpm/conf.d/mongo.ini
+    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/cli/conf.d/mongo.ini
 
+    echo 'extension=mongodb.so' | sudo tee /etc/php5/mods-available/mongodb.ini
     ln -s /etc/php5/mods-available/mongodb.ini /etc/php5/fpm/conf.d/mongodb.ini
     ln -s /etc/php5/mods-available/mongodb.ini /etc/php5/cli/conf.d/mongodb.ini
+
     sudo service php5-fpm restart
 fi


### PR DESCRIPTION
#### Changes
It looks like the Laravel MongoDB package requires the deprecated `mongo` extension to be installed (so the `MongoClient` class is accessible) in addition to the new `mongodb` extension. This pull request adds that dependency to our DS Homestead.

---

For review: @blisteringherb 