### PR TITLE
Updating to PHP 7.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   Homestead.configure(config, YAML::load(File.read(path + '/Homestead.yaml')))
 
-  config.vm.box_version	= "0.3.0"
+  config.vm.box_version	= "0.4.4"
 
   config.vm.provision "shell", path: path + "/scripts/customizations.sh"
 

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -63,7 +63,7 @@ class Homestead
     if settings.has_key?("variables")
       settings["variables"].each do |var|
         config.vm.provision "shell" do |s|
-            s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php5/fpm/php-fpm.conf && service php5-fpm restart"
+            s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/7.0/fpm/php-fpm.conf && service php7.0-fpm restart"
             s.args = [var["key"], var["value"]]
         end
       end

--- a/scripts/mongodb.sh
+++ b/scripts/mongodb.sh
@@ -26,16 +26,16 @@ PHP_IS_INSTALLED=$?
 
 if [ $PHP_IS_INSTALLED -eq 0 ]; then
     # install dependencies
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install php-pear php7.0-dev pkg-config
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install php-pear php7.0-dev pkg-config php7.0-mongo
 
     # install php extencion
     sudo pecl install mongo
     sudo pecl install mongodb
 
     # add extencion file and restart service
+    echo 'extension=mongo.so' | sudo tee /etc/php/7.0/mods-available/mongo.ini
+
     echo 'extension=mongodb.so' | sudo tee /etc/php/7.0/mods-available/mongodb.ini
 
-    ln -s /etc/php/7.0/mods-available/mongodb.ini /etc/php/7.0/fpm/conf.d/mongodb.ini
-    ln -s /etc/php/7.0/mods-available/mongodb.ini /etc/php/7.0/cli/conf.d/mongodb.ini
     sudo service php7.0-fpm restart
 fi

--- a/scripts/mongodb.sh
+++ b/scripts/mongodb.sh
@@ -26,20 +26,16 @@ PHP_IS_INSTALLED=$?
 
 if [ $PHP_IS_INSTALLED -eq 0 ]; then
     # install dependencies
-    sudo apt-get -y install php-pear php5-dev pkg-config
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install php-pear php7.0-dev pkg-config
 
     # install php extencion
     sudo pecl install mongo
     sudo pecl install mongodb
 
     # add extencion file and restart service
-    echo 'extension=mongo.so' | sudo tee /etc/php5/mods-available/mongo.ini
-    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/fpm/conf.d/mongo.ini
-    ln -s /etc/php5/mods-available/mongo.ini /etc/php5/cli/conf.d/mongo.ini
+    echo 'extension=mongodb.so' | sudo tee /etc/php/7.0/mods-available/mongodb.ini
 
-    echo 'extension=mongodb.so' | sudo tee /etc/php5/mods-available/mongodb.ini
-    ln -s /etc/php5/mods-available/mongodb.ini /etc/php5/fpm/conf.d/mongodb.ini
-    ln -s /etc/php5/mods-available/mongodb.ini /etc/php5/cli/conf.d/mongodb.ini
-
-    sudo service php5-fpm restart
+    ln -s /etc/php/7.0/mods-available/mongodb.ini /etc/php/7.0/fpm/conf.d/mongodb.ini
+    ln -s /etc/php/7.0/mods-available/mongodb.ini /etc/php/7.0/cli/conf.d/mongodb.ini
+    sudo service php7.0-fpm restart
 fi

--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -40,5 +40,5 @@ block="server {
 echo "$block" > "/etc/nginx/sites-available/$1"
 ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 service nginx restart
-service php5-fpm restart
+service php7.0-fpm restart
 service hhvm restart

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -25,7 +25,7 @@ block="server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/var/run/php7.0-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
     }
@@ -39,4 +39,4 @@ block="server {
 echo "$block" > "/etc/nginx/sites-available/$1"
 ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 service nginx restart
-service php5-fpm restart
+service php7.0-fpm restart

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -25,7 +25,7 @@ block="server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php7.0-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.0-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
     }


### PR DESCRIPTION
* Changing all references to point to PHP7
* The current version of the laravel/homestead box is v0.5.0, but
  because it's running Ubuntu 16.04, and we're running Ubuntu 14.04
  in production. We'll update when we update production.

To test:  
Run `vagrant destroy` then `vagrant up` to make sure the box gets provisioned properly.  

References https://github.com/DoSomething/devops/issues/182