### PR TITLE
Updating to add some more useful aliases.

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,7 +1,11 @@
 alias ..="cd .."
 alias ...="cd ../.."
 
+alias artisan="php artisan"
 alias art="php artisan"
+
+alias phpunit="vendor/bin/phpunit"
+alias t="vendor/bin/phpunit"
 
 alias h='cd ~'
 alias c='clear'


### PR DESCRIPTION
This PR fixes a longstanding gripe of mine... always getting errors if I type out `artisan` instead of `art`, and adding an alias for `vendor/bin/phpunit` 🎉 

---
@DFurnes @angaither @sbsmith86 